### PR TITLE
Add uploaded files

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci:"
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "go:"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
This pull request adds a new Dependabot configuration file to automate dependency updates for both GitHub Actions workflows and Go modules. The configuration schedules weekly update checks, groups all dependencies into a single pull request per ecosystem, and sets a limit on the number of open pull requests.

Dependency update automation:

* Added `.github/workflows/dependabot.yml` to configure Dependabot for both `github-actions` and `gomod` ecosystems, with weekly update schedules and grouped dependency updates.
* Set commit message prefixes (`ci:` for GitHub Actions and `go:` for Go modules) and limited the number of open Dependabot pull requests to 20 per ecosystem.